### PR TITLE
Identity v3 - Add Get Projects by User (#529)

### DIFF
--- a/acceptance/openstack/identity/v3/users_test.go
+++ b/acceptance/openstack/identity/v3/users_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/gophercloud/gophercloud/acceptance/clients"
 	"github.com/gophercloud/gophercloud/acceptance/tools"
 	"github.com/gophercloud/gophercloud/openstack/identity/v3/groups"
+	"github.com/gophercloud/gophercloud/openstack/identity/v3/projects"
 	"github.com/gophercloud/gophercloud/openstack/identity/v3/users"
 )
 
@@ -152,5 +153,37 @@ func TestUsersListGroups(t *testing.T) {
 	for _, group := range allGroups {
 		tools.PrintResource(t, group)
 		tools.PrintResource(t, group.Extra)
+	}
+}
+
+func TestUsersListProjects(t *testing.T) {
+	client, err := clients.NewIdentityV3Client()
+	if err != nil {
+		t.Fatalf("Unable to obtain an identity client: %v", err)
+	}
+	allUserPages, err := users.List(client, nil).AllPages()
+	if err != nil {
+		t.Fatalf("Unable to list users: %v", err)
+	}
+
+	allUsers, err := users.ExtractUsers(allUserPages)
+	if err != nil {
+		t.Fatalf("Unable to extract users: %v", err)
+	}
+
+	user := allUsers[0]
+
+	allProjectPages, err := users.ListProjects(client, user.ID).AllPages()
+	if err != nil {
+		t.Fatalf("Unable to list projects: %v", err)
+	}
+
+	allProjects, err := projects.ExtractProjects(allProjectPages)
+	if err != nil {
+		t.Fatalf("Unable to extract projects: %v", err)
+	}
+
+	for _, project := range allProjects {
+		tools.PrintResource(t, project)
 	}
 }

--- a/openstack/identity/v3/users/doc.go
+++ b/openstack/identity/v3/users/doc.go
@@ -71,7 +71,7 @@ Example to List Groups a User Belongs To
 		panic(err)
 	}
 
-	allGroups, err := users.ExtractGroups(allPages)
+	allGroups, err := groups.ExtractGroups(allPages)
 	if err != nil {
 		panic(err)
 	}
@@ -79,5 +79,24 @@ Example to List Groups a User Belongs To
 	for _, group := range allGroups {
 		fmt.Printf("%+v\n", group)
 	}
+
+Example to List Projects a User Belongs To
+
+	userID := "0fe36e73809d46aeae6705c39077b1b3"
+
+	allPages, err := users.ListProjects(identityClient, userID).AllPages()
+	if err != nil {
+		panic(err)
+	}
+
+	allProjects, err := projects.ExtractProjects(allPages)
+	if err != nil {
+		panic(err)
+	}
+
+	for _, project := range allProjects {
+		fmt.Printf("%+v\n", project)
+	}
+
 */
 package users

--- a/openstack/identity/v3/users/requests.go
+++ b/openstack/identity/v3/users/requests.go
@@ -3,6 +3,7 @@ package users
 import (
 	"github.com/gophercloud/gophercloud"
 	"github.com/gophercloud/gophercloud/openstack/identity/v3/groups"
+	"github.com/gophercloud/gophercloud/openstack/identity/v3/projects"
 	"github.com/gophercloud/gophercloud/pagination"
 )
 
@@ -214,5 +215,13 @@ func ListGroups(client *gophercloud.ServiceClient, userID string) pagination.Pag
 	url := listGroupsURL(client, userID)
 	return pagination.NewPager(client, url, func(r pagination.PageResult) pagination.Page {
 		return groups.GroupPage{pagination.LinkedPageBase{PageResult: r}}
+	})
+}
+
+// ListProjects enumerates groups user belongs to.
+func ListProjects(client *gophercloud.ServiceClient, userID string) pagination.Pager {
+	url := listProjectsURL(client, userID)
+	return pagination.NewPager(client, url, func(r pagination.PageResult) pagination.Page {
+		return projects.ProjectPage{pagination.LinkedPageBase{PageResult: r}}
 	})
 }

--- a/openstack/identity/v3/users/testing/fixtures.go
+++ b/openstack/identity/v3/users/testing/fixtures.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/gophercloud/gophercloud"
 	"github.com/gophercloud/gophercloud/openstack/identity/v3/groups"
+	"github.com/gophercloud/gophercloud/openstack/identity/v3/projects"
 	"github.com/gophercloud/gophercloud/openstack/identity/v3/users"
 	th "github.com/gophercloud/gophercloud/testhelper"
 	"github.com/gophercloud/gophercloud/testhelper/client"
@@ -195,6 +196,41 @@ const ListGroupsOutput = `
 }
 `
 
+// ListProjectsOutput provides a ListProjects result.
+const ListProjectsOutput = `
+{
+    "links": {
+        "next": null,
+        "previous": null,
+        "self": "http://localhost:5000/identity/v3/users/foobar/projects"
+    },
+    "projects": [
+        {
+            "description": "my first project",
+            "domain_id": "11111",
+            "enabled": true,
+            "id": "abcde",
+            "links": {
+                "self": "http://localhost:5000/identity/v3/projects/abcde"
+            },
+            "name": "project 1",
+            "parent_id": "11111"
+        },
+        {
+            "description": "my second project",
+            "domain_id": "22222",
+            "enabled": true,
+            "id": "bcdef",
+            "links": {
+                "self": "http://localhost:5000/identity/v3/projects/bcdef"
+            },
+            "name": "project 2",
+            "parent_id": "22222"
+        }
+    ]
+}
+`
+
 // FirstUser is the first user in the List request.
 var nilTime time.Time
 var FirstUser = users.User{
@@ -300,6 +336,26 @@ var SecondGroup = groups.Group{
 
 var ExpectedGroupsSlice = []groups.Group{FirstGroup, SecondGroup}
 
+var FirstProject = projects.Project{
+	Description: "my first project",
+	DomainID:    "11111",
+	Enabled:     true,
+	ID:          "abcde",
+	Name:        "project 1",
+	ParentID:    "11111",
+}
+
+var SecondProject = projects.Project{
+	Description: "my second project",
+	DomainID:    "22222",
+	Enabled:     true,
+	ID:          "bcdef",
+	Name:        "project 2",
+	ParentID:    "22222",
+}
+
+var ExpectedProjectsSlice = []projects.Project{FirstProject, SecondProject}
+
 // HandleListUsersSuccessfully creates an HTTP handler at `/users` on the
 // test handler mux that responds with a list of two users.
 func HandleListUsersSuccessfully(t *testing.T) {
@@ -379,7 +435,7 @@ func HandleDeleteUserSuccessfully(t *testing.T) {
 }
 
 // HandleListUserGroupsSuccessfully creates an HTTP handler at /users/{userID}/groups
-// on the test handler mux that respons wit a list of two groups
+// on the test handler mux that respons with a list of two groups
 func HandleListUserGroupsSuccessfully(t *testing.T) {
 	th.Mux.HandleFunc("/users/9fe1d3/groups", func(w http.ResponseWriter, r *http.Request) {
 		th.TestMethod(t, r, "GET")
@@ -389,5 +445,19 @@ func HandleListUserGroupsSuccessfully(t *testing.T) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 		fmt.Fprintf(w, ListGroupsOutput)
+	})
+}
+
+// HandleListUserProjectsSuccessfully creates an HTTP handler at /users/{userID}/projects
+// on the test handler mux that respons wit a list of two projects
+func HandleListUserProjectsSuccessfully(t *testing.T) {
+	th.Mux.HandleFunc("/users/9fe1d3/projects", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "Accept", "application/json")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprintf(w, ListProjectsOutput)
 	})
 }

--- a/openstack/identity/v3/users/testing/requests_test.go
+++ b/openstack/identity/v3/users/testing/requests_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/gophercloud/gophercloud/openstack/identity/v3/groups"
+	"github.com/gophercloud/gophercloud/openstack/identity/v3/projects"
 	"github.com/gophercloud/gophercloud/openstack/identity/v3/users"
 	"github.com/gophercloud/gophercloud/pagination"
 	th "github.com/gophercloud/gophercloud/testhelper"
@@ -145,4 +146,15 @@ func TestListUserGroups(t *testing.T) {
 	actual, err := groups.ExtractGroups(allPages)
 	th.AssertNoErr(t, err)
 	th.CheckDeepEquals(t, ExpectedGroupsSlice, actual)
+}
+
+func TestListUserProjects(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	HandleListUserProjectsSuccessfully(t)
+	allPages, err := users.ListProjects(client.ServiceClient(), "9fe1d3").AllPages()
+	th.AssertNoErr(t, err)
+	actual, err := projects.ExtractProjects(allPages)
+	th.AssertNoErr(t, err)
+	th.CheckDeepEquals(t, ExpectedProjectsSlice, actual)
 }

--- a/openstack/identity/v3/users/urls.go
+++ b/openstack/identity/v3/users/urls.go
@@ -25,3 +25,7 @@ func deleteURL(client *gophercloud.ServiceClient, userID string) string {
 func listGroupsURL(client *gophercloud.ServiceClient, userID string) string {
 	return client.ServiceURL("users", userID, "groups")
 }
+
+func listProjectsURL(client *gophercloud.ServiceClient, userID string) string {
+	return client.ServiceURL("users", userID, "projects")
+}


### PR DESCRIPTION
* Add ListUsers function for Gophercloud's OpenStack Identity v3 API

- Allows a caller to get the list of projects that a specified user has access to
- Effectively wraps OpenStack Identity v3 API function /v3/users/{user_id}/projects
- Based on implementation of ListGroups

Note: In line with "ListGroups" uses sample response body from https://developer.openstack.org/api-ref/identity/v3/#list-projects-for-user for test

* fix doc and add acceptance test

* fix test to point to correct fixture

* add CC BY 3.0 attribution where applicable

* change data to be mocked instead of doc ref

* json syntax fix

* fix doc typo

Prior to a PR being reviewed, there needs to be a Github issue that the PR
addresses. Replace the brackets and text below with that issue number.

For #[PUT ISSUE NUMBER HERE]

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:

[PUT URLS HERE]
